### PR TITLE
Shades of grey

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,23 @@ Python matplotlib script to toggle between the figure formatting for keynote and
 
 Using the matplotlib.rcParams[] function within python, changes to the figure formatting can be made for the duration of the existing python session. The major change is the swapping of a color palatte from black on white to white on black. Other improvements are made to improve legibility on terrible projectors. The author has seen far too many terrible attrocities committed with keynote talks on default white backgrounds. The line must be drawn here.
 
-##Detailed changes (Manuscript -> Keynote)
-- Line color : Black to white
-- Text color : Black to white
-- Axes face color : White to black
-- Axes edge color : Black to white
-- Axes label color : Black to white
-- Tick color : Black to white
-- Grid color : Black to white
-- Figure face color : White to black
-- Figure edge color : White to black
-- Default plot line color : Black to white
-- Line width : 1.0 to 2.0
-- Font size : 8 to 14
-- Font family : Serif to sans-serif
-- LaTeX : On to off
+##Detailed changes (Manuscript -> Keynote (black) / Keynote (grey))
+- Line color : Black to white / black
+- Text color : Black to white / black
+- Axes face color : White to black / grey
+- Axes edge color : Black to white / black
+- Axes label color : Black to white / black
+- Tick color : Black to white / black
+- Grid color : Black to white / black
+- Figure face color : White to black / grey
+- Figure edge color : White to black / grey
+- Default plot line color : Black to white / black
+- Line width : 1.0 to 2.0 / 2.0
+- Font size : 8 to 14 / 14
+- Font family : Serif to sans-serif / sans-serif
+- LaTeX : On to off / off
  
 ##Things to-do
 - Include transparency options by default for keynote figures
 - Adjust rendering of math to avoid serifed LaTeX fonts in keynote mode
+- Slightly darken label colors, etc, to bring out the data first and foremost

--- a/py_keynote_figs.py
+++ b/py_keynote_figs.py
@@ -23,6 +23,28 @@ def keynote_figs():
 	matplotlib.rcParams['font.family'] = 'sans-serif'
 	matplotlib.rcParams['text.usetex'] = False
 
+def keynote_figs2():
+	matplotlib.rcParams['lines.color'] = 'black'
+	matplotlib.rcParams['patch.edgecolor'] = 'black'
+	matplotlib.rcParams['text.color'] = 'black'
+	matplotlib.rcParams['axes.facecolor'] = '#f1f1f1'
+	matplotlib.rcParams['axes.edgecolor'] = 'black'
+	matplotlib.rcParams['axes.labelcolor'] = 'black'
+	matplotlib.rcParams['xtick.color'] = 'black'
+	matplotlib.rcParams['ytick.color'] = 'black'
+	matplotlib.rcParams['grid.color'] = 'black'
+	matplotlib.rcParams['figure.facecolor'] = '#f1f1f1'
+	matplotlib.rcParams['figure.edgecolor'] = '#f1f1f1'
+	matplotlib.rcParams['savefig.facecolor'] = '#f1f1f1'
+	matplotlib.rcParams['savefig.edgecolor'] = '#f1f1f1'
+	cols = (brewer2mpl.get_map('Set1', 'qualitative', 7)).mpl_colors
+	cols.insert(0,(0.,0.,0.))
+	matplotlib.rcParams['axes.prop_cycle'] = matplotlib.cycler('color', cols)
+	matplotlib.rcParams['font.size'] = 14
+	matplotlib.rcParams['lines.linewidth'] = 2.0
+	matplotlib.rcParams['font.family'] = 'sans-serif'
+	matplotlib.rcParams['text.usetex'] = False
+
 def latex_figs():
 	matplotlib.rcParams['lines.color'] = 'black'
 	matplotlib.rcParams['patch.edgecolor'] = 'black'


### PR DESCRIPTION
Added a second function, keynote_figs2(), to change the matplotlib formatting options for a slightly inverted color map for keynote figures. The background is changed from a bright white to a slightly darker (but still pretty light) shade of grey.
